### PR TITLE
Fulling implementing kick single job functionality

### DIFF
--- a/lib/Beanstalk/Command/KickJob.php
+++ b/lib/Beanstalk/Command/KickJob.php
@@ -16,7 +16,7 @@ use Beanstalk\Exception;
  *
  * @author Joshua Dechant <jdechant@shapeup.com>
  */
-class Kick extends Command
+class KickJob extends Command
 {
 
     protected $id;

--- a/lib/Beanstalk/Connection.php
+++ b/lib/Beanstalk/Connection.php
@@ -271,6 +271,19 @@ class Connection
     }
 
     /**
+     * Kick Job command
+     *
+     * The kick job command kicks a single job from buried back to ready state.
+     *
+     * @param  integer $id Id of the job to kick.
+     * @return boolean Returns true if the job was successfully kicked.
+     */
+    public function kickJob($id)
+    {
+        return $this->dispatch(new Command\KickJob($id));
+    }
+
+    /**
      * Return job $id
      *
      * @param  integer              $id Id of job to return

--- a/lib/Beanstalk/Job.php
+++ b/lib/Beanstalk/Job.php
@@ -100,7 +100,7 @@ class Job
      * its state as "ready") to be run by any client. It is normally used when the job
      * fails because of a transitory error.
      *
-     * @param  integer            $delay    Number of seconds to wait before putting the job in the ready queue. 
+     * @param  integer            $delay    Number of seconds to wait before putting the job in the ready queue.
      *                                      The job will be in the "delayed" state during this time
      * @param  integer            $priority A new priority to assign to the job
      * @throws BeanstalkException
@@ -123,6 +123,18 @@ class Job
     public function bury($priority = 2048)
     {
         return $this->getConnection()->bury($this->getId(), $priority);
+    }
+
+    /**
+     * Kick the job
+     *
+     * The kick command puts a buried job back to the ready state.
+     * @return boolean Returns true if job was successfully kicked.
+     * @throws \Beanstalk\Exception  When the job cannot be found or is not in a kickable state.
+     * @throws \Beanstalk\Exception  When any other error occurs
+     */
+    public function kick() {
+      return $this->getConnection()->kickJob($this->getId());
     }
 
     /**

--- a/tests/UnitTests/BeanstalkTests/CommandTests/KickJobTest.php
+++ b/tests/UnitTests/BeanstalkTests/CommandTests/KickJobTest.php
@@ -1,0 +1,56 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+namespace UnitTests\BeanstalkTests\CommandTests\KickJobTest;
+
+use PHPUnit_Framework_TestCase;
+use Beanstalk\Command\KickJob;
+
+class TestCases extends PHPUnit_Framework_TestCase
+{
+
+    public function testGetCommand()
+    {
+        $command = new KickJob(12345);
+        $this->assertEquals('kick-job 12345', $command->getCommand());
+
+        $command = new KickJob('98765');
+        $this->assertEquals('kick-job 98765', $command->getCommand());
+    }
+
+    public function testHasNoData()
+    {
+        $command = new KickJob(12345);
+        $this->assertFalse($command->getData());
+    }
+
+    public function testReturnsNoData()
+    {
+        $command = new KickJob(12345);
+        $this->assertFalse($command->returnsData());
+    }
+
+    public function testParseResponseOnSuccess()
+    {
+        $command = new KickJob(12345);
+        $this->assertEquals(true, $command->parseResponse('KICKED'));
+        $this->assertInternalType('boolean', $command->parseResponse('KICKED'));
+    }
+
+    public function testParseResponseOnNotFoundErrors()
+    {
+        $this->setExpectedException('\Beanstalk\Exception', '', \Beanstalk\Exception::NOT_FOUND);
+
+        $command = new KickJob(12345);
+        $command->parseResponse('NOT_FOUND');
+    }
+
+    public function testParseResponseOnOtherErrors()
+    {
+        $this->setExpectedException('\Beanstalk\Exception', '', \Beanstalk\Exception::UNKNOWN);
+
+        $command = new KickJob(12345);
+        $command->parseResponse('This is wack');
+    }
+
+}

--- a/tests/UnitTests/BeanstalkTests/ConnectionTest.php
+++ b/tests/UnitTests/BeanstalkTests/ConnectionTest.php
@@ -228,6 +228,19 @@ class TestCases extends PHPUnit_Framework_TestCase
         $this->assertEquals(4, $this->conn->kick(4));
     }
 
+    public function testKickJobWritesToStream()
+    {
+        $this->stream->expects($this->once())
+                     ->method('write')
+                     ->with($this->equalTo("kick-job 12345\r\n"));
+
+        $this->stream->expects($this->once())
+                     ->method('readLine')
+                     ->will($this->returnValue('KICKED'));
+
+        $this->assertEquals(true, $this->conn->kickJob(12345));
+    }
+
     public function testPeekWritesToStream()
     {
         $this->stream->expects($this->once())

--- a/tests/UnitTests/BeanstalkTests/JobTest.php
+++ b/tests/UnitTests/BeanstalkTests/JobTest.php
@@ -13,7 +13,7 @@ class TestCases extends PHPUnit_Framework_TestCase
     {
         $this->conn = $this->getMock(
             'Beanstalk\Connection',
-            array('connect', 'delete', 'touch', 'release', 'bury', 'statsJob'),
+            array('connect', 'delete', 'touch', 'release', 'bury', 'kickJob', 'statsJob'),
             array('localhost:11300', $this->getMock('Beanstalk\Connection\Stream'))
         );
     }
@@ -124,6 +124,16 @@ class TestCases extends PHPUnit_Framework_TestCase
 
         $job = new Job($this->conn, 8867, '{"content":"Hello World!"}');
         $this->assertTrue($job->bury(65840));
+    }
+
+    public function testCanKickBuriedJob() {
+      $this->conn->expects($this->once())
+        ->method('kickJob')
+        ->with($this->equalTo(1234))
+        ->will($this->returnValue(true));
+
+      $job = new Job($this->conn, 1234, '{"content":"Hello World!"}');
+      $this->assertTrue($job->kick());
     }
 
     public function testCanGetJobStats()


### PR DESCRIPTION
In beanstalk >= 1.8 there is the ability to kick a single buried job back to the ready state. It looks like this was in the beginnings of being implemented in the code. I needed this functionality for a project I was working on so I fleshed out the implementation and wrote corresponding unit tests. 